### PR TITLE
Avoid duplicate gifs

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,12 +5,17 @@ const recordKeyButton = document.querySelector("#record-key");
 const deleteKeyButton = document.querySelector("#delete-key");
 const clearGifButton = document.querySelector("#clear-gifs");
 const gifContainer = document.querySelector("#gif-container");
+const gifIDSet = new Set();
 
 async function makeGiphyRequest(searchItem, apiKey) {
   try {
-    let giphyResponse = await axios.get("http://api.giphy.com/v1/gifs/search", {
-      params: { q: searchItem, api_key: apiKey },
+    let giphyResponse = await axios.get("http://api.giphy.com/v1/gifs/random", {
+      params: { tag: searchItem, api_key: apiKey, rating: "pg-13" },
     });
+    if (gifIDSet.has(giphyResponse.data.data.id)) {
+      return makeGiphyRequest(searchItem, apiKey);
+    }
+    gifIDSet.add(giphyResponse.data.data.id);
     return giphyResponse;
   } catch (error) {
     console.log(error);
@@ -30,13 +35,14 @@ deleteKeyButton.addEventListener("click", function (evt) {
 submit.addEventListener("click", async function (evt) {
   evt.preventDefault();
   if (checkInputs()) {
-    let gifArray = await makeGiphyRequest(searchBar.value, keyTextBar.value);
-    addRandomGif(gifArray.data.data);
+    let gifInfo = await makeGiphyRequest(searchBar.value, keyTextBar.value);
+    addRandomGif(gifInfo.data.data);
   }
 });
 
 clearGifButton.addEventListener("click", function (evt) {
   gifContainer.textContent = "";
+  gifIDSet.clear();
 });
 
 if (localStorage.getItem("key")) {
@@ -47,8 +53,8 @@ function checkInputs() {
   return Boolean(keyTextBar.value && searchBar.value);
 }
 
-async function addRandomGif(array) {
+async function addRandomGif(gifInfo) {
   let gif = document.createElement("img");
-  gif.src = array[Math.floor(Math.random() * array.length)].images.original.url;
+  gif.src = gifInfo.images.original.url;
   gifContainer.append(gif);
 }


### PR DESCRIPTION
Changed to a random endpoint rather than the search one, described in the GIPHY API. This provides a single random gif instead of pulling a random index from an array.

Additionally, this branch includes a Set that tracks the ID numbers of the appended gifs. This means that in the rare event that GIPHY responds with the same gif, it won't be appended to the DOM. Instead, another random gif is requested from GIPHY - if it _still_ isn't unique, then the most likely solution is that GIPHY has run out of unique gifs for this search term. A message conveying this is then displayed to the user via the search bar's custom validity message.